### PR TITLE
Closes #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Fixed a bug related to a missing dispose call for animation controllers in MarkerWidgets.  (see [issue #1](https://github.com/jbadger3/google_maps_marker_widgets/issues/1))
+
 ## 1.0.0
 
 * Initial development and release.

--- a/lib/src/marker_widget.dart
+++ b/lib/src/marker_widget.dart
@@ -45,6 +45,7 @@ class _MarkerWidgetState extends State<MarkerWidget>
 
   @override
   void dispose() {
+    _markerUpdateAnimationController.dispose();
     widget.animation?.removeListener(updateMarkerWidgetsController);
     super.dispose();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/jbadger3/google_maps_marker_widgets/issues?q=i
 topics:
   - google-maps-flutter
   - map
-version: 1.0.0
+version: 1.0.1
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
Fixes missing dispose for animation controller in marker_widget.dart